### PR TITLE
Add initial DuckDB schema migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,13 @@ npm run build
 You can preview the production build with `npm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+
+## Database migrations
+
+This project includes SQL migrations for the DuckDB backend. The scripts live in the `migrations/` directory. To apply the initial schema, upload the SQL file to the FastAPI service:
+
+```sh
+curl -X POST -F "sql_file=@migrations/001_init.sql" https://web-production-b1513.up.railway.app/query-file
+```
+
+This will create the tables used by the app for tests, questions and student attempts.

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -1,0 +1,39 @@
+-- Migration script to set up initial database schema for test randomizer.
+
+CREATE TABLE IF NOT EXISTS tests (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS questions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    test_id INTEGER NOT NULL REFERENCES tests(id) ON DELETE CASCADE,
+    question_text TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS choices (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    question_id INTEGER NOT NULL REFERENCES questions(id) ON DELETE CASCADE,
+    choice_text TEXT NOT NULL,
+    is_correct BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+CREATE TABLE IF NOT EXISTS test_attempts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    test_id INTEGER NOT NULL REFERENCES tests(id) ON DELETE CASCADE,
+    student_name TEXT NOT NULL,
+    started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    completed_at TIMESTAMP,
+    score INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS attempt_answers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    attempt_id INTEGER NOT NULL REFERENCES test_attempts(id) ON DELETE CASCADE,
+    question_id INTEGER NOT NULL REFERENCES questions(id) ON DELETE CASCADE,
+    choice_id INTEGER NOT NULL REFERENCES choices(id),
+    is_correct BOOLEAN NOT NULL DEFAULT FALSE
+);
+


### PR DESCRIPTION
## Summary
- add SQL migration to create tests, questions, choices and attempt tables
- document running migrations in README

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1181/chrome-linux/chrome)*
- `npx playwright install` *(fails: Download failed: server returned code 403)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689157586bf883248eafe4cfececd34a