### PR TITLE
Add frontend and sample data for test randomizer

### DIFF
--- a/e2e/demo.test.js
+++ b/e2e/demo.test.js
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-test('home page has expected h1', async ({ page }) => {
-	await page.goto('/');
-	await expect(page.locator('h1')).toBeVisible();
+test('home page has expected heading', async ({ page }) => {
+        await page.goto('/');
+        await expect(page.locator('h1', { hasText: 'Law Test Randomizer' })).toBeVisible();
 });

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -37,3 +37,29 @@ CREATE TABLE IF NOT EXISTS attempt_answers (
     is_correct BOOLEAN NOT NULL DEFAULT FALSE
 );
 
+-- ---------------------------------------------------------------------------
+-- Sample seed data to make the application usable out of the box.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO tests (title, description) VALUES
+    ('Civics Sample', 'Basic questions about U.S. law');
+
+-- Questions for test id 1
+INSERT INTO questions (test_id, question_text) VALUES
+    (1, 'What is the supreme law of the land?'),
+    (1, 'Who is in charge of the executive branch?');
+
+-- Choices for question 1
+INSERT INTO choices (question_id, choice_text, is_correct) VALUES
+    (1, 'The Constitution', TRUE),
+    (1, 'The Federalist Papers', FALSE),
+    (1, 'The Declaration of Independence', FALSE),
+    (1, 'The Articles of Confederation', FALSE);
+
+-- Choices for question 2
+INSERT INTO choices (question_id, choice_text, is_correct) VALUES
+    (2, 'The President', TRUE),
+    (2, 'The Chief Justice', FALSE),
+    (2, 'The Speaker of the House', FALSE),
+    (2, 'The Senate Majority Leader', FALSE);
+

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,0 +1,26 @@
+const BASE_URL = 'https://web-production-b1513.up.railway.app';
+
+export async function query(sql) {
+        const res = await fetch(`${BASE_URL}/query`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ sql, source: 'duckdb' })
+        });
+        if (!res.ok) {
+                throw new Error(await res.text());
+        }
+        return res.json();
+}
+
+export async function uploadSQL(file) {
+        const form = new FormData();
+        form.append('sql_file', file);
+        const res = await fetch(`${BASE_URL}/query-file`, {
+                method: 'POST',
+                body: form
+        });
+        if (!res.ok) {
+                throw new Error(await res.text());
+        }
+        return res.json();
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,2 +1,53 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+<script>
+        import { onMount } from 'svelte';
+        import { query, uploadSQL } from '$lib/api';
+
+        let tests = [];
+        let error = '';
+        let file;
+
+        async function loadTests() {
+                try {
+                        const res = await query('select id, title, description from tests');
+                        tests = Array.isArray(res) ? res : res?.data ?? [];
+                } catch (e) {
+                        error = 'Failed to load tests';
+                }
+        }
+
+        onMount(loadTests);
+
+        async function handleUpload() {
+                if (!file) return;
+                try {
+                        await uploadSQL(file);
+                        file = null;
+                        await loadTests();
+                } catch (e) {
+                        error = 'Upload failed';
+                }
+        }
+</script>
+
+<h1>Law Test Randomizer</h1>
+
+<section>
+        <h2>Upload Test (SQL)</h2>
+        <input type="file" accept=".sql" on:change={(e) => (file = e.target.files[0])} />
+        <button on:click|preventDefault={handleUpload}>Upload</button>
+</section>
+
+{#if error}
+        <p class="error">{error}</p>
+{/if}
+
+<h2>Available Tests</h2>
+{#if tests.length}
+        <ul>
+                {#each tests as t}
+                        <li><a href={`/tests/${t.id}`}>{t.title}</a></li>
+                {/each}
+        </ul>
+{:else}
+        <p>No tests available.</p>
+{/if}

--- a/src/routes/tests/[id]/+page.svelte
+++ b/src/routes/tests/[id]/+page.svelte
@@ -1,0 +1,95 @@
+<script>
+        import { query } from '$lib/api';
+
+        let { params } = $props();
+        let test;
+        let questions = [];
+        let student = '';
+        let submitted = false;
+        let score = 0;
+        let error = '';
+
+        function shuffle(arr) {
+                return arr.sort(() => Math.random() - 0.5);
+        }
+
+        async function load() {
+                try {
+                        const tRes = await query(`select id, title from tests where id = ${params.id}`);
+                        const tData = Array.isArray(tRes) ? tRes : tRes?.data ?? [];
+                        test = tData[0];
+
+                        const qRes = await query(`
+                                select q.id as question_id, q.question_text, c.id as choice_id, c.choice_text, c.is_correct
+                                from questions q join choices c on q.id = c.question_id
+                                where q.test_id = ${params.id}
+                        `);
+                        const rows = Array.isArray(qRes) ? qRes : qRes?.data ?? [];
+                        const map = new Map();
+                        for (const r of rows) {
+                                if (!map.has(r.question_id)) {
+                                        map.set(r.question_id, {
+                                                id: r.question_id,
+                                                text: r.question_text,
+                                                choices: []
+                                        });
+                                }
+                                map.get(r.question_id).choices.push({
+                                        id: r.choice_id,
+                                        text: r.choice_text,
+                                        is_correct: r.is_correct
+                                });
+                        }
+                        questions = shuffle(
+                                Array.from(map.values()).map((q) => ({
+                                        ...q,
+                                        choices: shuffle(q.choices),
+                                        selected: null
+                                }))
+                        );
+                } catch (e) {
+                        error = 'Failed to load test';
+                }
+        }
+
+        load();
+
+        function submit() {
+                score = 0;
+                for (const q of questions) {
+                        const choice = q.choices.find((c) => c.id == q.selected);
+                        if (choice?.is_correct) score++;
+                }
+                submitted = true;
+        }
+</script>
+
+{#if error}
+<p>{error}</p>
+{:else if !test}
+<p>Loading...</p>
+{:else}
+<h1>{test.title}</h1>
+{#if !submitted}
+        <div class="meta">
+                <label>
+                        Name:
+                        <input bind:value={student} />
+                </label>
+        </div>
+        {#each questions as q, i}
+                <div class="question">
+                        <p>{i + 1}. {q.text}</p>
+                        {#each q.choices as c}
+                                <label>
+                                        <input type="radio" name={`q${q.id}`} value={c.id} on:change={() => (q.selected = c.id)} />
+                                        {c.text}
+                                </label>
+                        {/each}
+                </div>
+        {/each}
+        <button on:click={submit}>Submit</button>
+{:else}
+        <p>Score: {score} / {questions.length}</p>
+{/if}
+{/if}


### PR DESCRIPTION
## Summary
- seed database with example civics test
- implement API helpers and homepage to upload SQL tests and list available tests
- add test-taking page that randomizes question order and scores answers

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1181/chrome-linux/chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6891593c21b08324b0db5c64c0dbe33d