### PR TITLE
feat: add bearer auth and styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,14 @@ curl -X POST -F "sql_file=@migrations/001_init.sql" https://web-production-b1513
 ```
 
 This will create the tables used by the app for tests, questions and student attempts.
+
+## Authentication
+
+API requests now require a bearer token. Set `VITE_API_TOKEN` in your environment before running the app:
+
+```sh
+export VITE_API_TOKEN=your_token_here
+npm run dev
+```
+
+The token will be sent in the `Authorization` header for all queries.

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,26 +1,33 @@
 const BASE_URL = 'https://web-production-b1513.up.railway.app';
+const TOKEN = import.meta.env.VITE_API_TOKEN;
 
 export async function query(sql) {
-        const res = await fetch(`${BASE_URL}/query`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ sql, source: 'duckdb' })
-        });
-        if (!res.ok) {
-                throw new Error(await res.text());
-        }
-        return res.json();
+	const res = await fetch(`${BASE_URL}/query`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			...(TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {})
+		},
+		body: JSON.stringify({ sql, source: 'duckdb' })
+	});
+	if (!res.ok) {
+		throw new Error(await res.text());
+	}
+	return res.json();
 }
 
 export async function uploadSQL(file) {
-        const form = new FormData();
-        form.append('sql_file', file);
-        const res = await fetch(`${BASE_URL}/query-file`, {
-                method: 'POST',
-                body: form
-        });
-        if (!res.ok) {
-                throw new Error(await res.text());
-        }
-        return res.json();
+	const form = new FormData();
+	form.append('sql_file', file);
+	const res = await fetch(`${BASE_URL}/query-file`, {
+		method: 'POST',
+		headers: {
+			...(TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {})
+		},
+		body: form
+	});
+	if (!res.ok) {
+		throw new Error(await res.text());
+	}
+	return res.json();
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,53 +1,109 @@
 <script>
-        import { onMount } from 'svelte';
-        import { query, uploadSQL } from '$lib/api';
+	import { onMount } from 'svelte';
+	import { query, uploadSQL } from '$lib/api';
+	import logo from '$lib/assets/favicon.svg';
 
-        let tests = [];
-        let error = '';
-        let file;
+	let tests = [];
+	let error = '';
+	let file;
 
-        async function loadTests() {
-                try {
-                        const res = await query('select id, title, description from tests');
-                        tests = Array.isArray(res) ? res : res?.data ?? [];
-                } catch (e) {
-                        error = 'Failed to load tests';
-                }
-        }
+	async function loadTests() {
+		try {
+			const res = await query('select id, title, description from tests');
+			tests = Array.isArray(res) ? res : (res?.data ?? []);
+		} catch (e) {
+			error = 'Failed to load tests';
+		}
+	}
 
-        onMount(loadTests);
+	onMount(loadTests);
 
-        async function handleUpload() {
-                if (!file) return;
-                try {
-                        await uploadSQL(file);
-                        file = null;
-                        await loadTests();
-                } catch (e) {
-                        error = 'Upload failed';
-                }
-        }
+	async function handleUpload() {
+		if (!file) return;
+		try {
+			await uploadSQL(file);
+			file = null;
+			await loadTests();
+		} catch (e) {
+			error = 'Upload failed';
+		}
+	}
 </script>
 
-<h1>Law Test Randomizer</h1>
+<main>
+	<header class="brand">
+		<img src={logo} alt="Law Test Randomizer logo" />
+		<h1>Law Test Randomizer</h1>
+	</header>
 
-<section>
-        <h2>Upload Test (SQL)</h2>
-        <input type="file" accept=".sql" on:change={(e) => (file = e.target.files[0])} />
-        <button on:click|preventDefault={handleUpload}>Upload</button>
-</section>
+	<section class="upload">
+		<h2>Upload Test (SQL)</h2>
+		<input type="file" accept=".sql" on:change={(e) => (file = e.target.files[0])} />
+		<button on:click|preventDefault={handleUpload}>Upload</button>
+	</section>
 
-{#if error}
-        <p class="error">{error}</p>
-{/if}
+	{#if error}
+		<p class="error">{error}</p>
+	{/if}
 
-<h2>Available Tests</h2>
-{#if tests.length}
-        <ul>
-                {#each tests as t}
-                        <li><a href={`/tests/${t.id}`}>{t.title}</a></li>
-                {/each}
-        </ul>
-{:else}
-        <p>No tests available.</p>
-{/if}
+	<section class="tests">
+		<h2>Available Tests</h2>
+		{#if tests.length}
+			<ul>
+				{#each tests as t}
+					<li><a href={`/tests/${t.id}`}>{t.title}</a></li>
+				{/each}
+			</ul>
+		{:else}
+			<p>No tests available.</p>
+		{/if}
+	</section>
+</main>
+
+<style>
+	main {
+		max-width: 60rem;
+		margin: 0 auto;
+		padding: 2rem;
+		font-family: system-ui, sans-serif;
+	}
+
+	.brand {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+		background-color: #0d3b66;
+		color: #fff;
+		padding: 1rem;
+		border-radius: 0.5rem;
+		margin-bottom: 2rem;
+	}
+
+	.brand img {
+		width: 40px;
+		height: 40px;
+	}
+
+	section {
+		margin-top: 1.5rem;
+	}
+
+	button {
+		background-color: #0d3b66;
+		color: #fff;
+		border: none;
+		padding: 0.5rem 1rem;
+		border-radius: 0.25rem;
+		cursor: pointer;
+	}
+
+	button:hover {
+		background-color: #092745;
+	}
+
+	.error {
+		color: #c00;
+		margin-top: 1rem;
+	}
+</style>


### PR DESCRIPTION
## Summary
- require bearer token for API requests
- add branded layout and styling to the home page
- document token usage in README

## Testing
- `npm test` (fails: Playwright browsers missing)
- `npx playwright install --with-deps` (fails: apt repositories 403)
- `npm run test:unit -- --run` (fails: Playwright browsers missing)


------
https://chatgpt.com/codex/tasks/task_e_6891652fb1cc8324b0099822f6a73132