### PR TITLE
Proxy API calls through server to avoid CORS

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,15 +1,12 @@
-import { PUBLIC_PASSPHRASE } from '$env/static/public';
+const BASE_URL = '/api';
 
-const BASE_URL = 'https://web-production-b1513.up.railway.app';
-
-export async function query(sql) {
+export async function query(fetch, sql) {
 	const res = await fetch(`${BASE_URL}/query`, {
 		method: 'POST',
 		headers: {
-			'Content-Type': 'application/json',
-			...(PUBLIC_PASSPHRASE ? { Authorization: `Bearer ${PUBLIC_PASSPHRASE}` } : {})
+			'Content-Type': 'application/json'
 		},
-		body: JSON.stringify({ sql, source: 'duckdb' })
+		body: JSON.stringify({ sql })
 	});
 	if (!res.ok) {
 		throw new Error(await res.text());
@@ -17,14 +14,11 @@ export async function query(sql) {
 	return res.json();
 }
 
-export async function uploadSQL(file) {
+export async function uploadSQL(fetch, file) {
 	const form = new FormData();
 	form.append('sql_file', file);
 	const res = await fetch(`${BASE_URL}/query-file`, {
 		method: 'POST',
-		headers: {
-			...(PASSPHRASE ? { Authorization: `Bearer ${PASSPHRASE}` } : {})
-		},
 		body: form
 	});
 	if (!res.ok) {

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -1,0 +1,28 @@
+import { fail } from '@sveltejs/kit';
+import { query, uploadSQL } from '$lib/api';
+
+export async function load({ fetch }) {
+	try {
+		const res = await query(fetch, 'select id, title, description from tests');
+		const tests = Array.isArray(res) ? res : (res?.data ?? []);
+		return { tests };
+	} catch {
+		return { tests: [], error: 'Failed to load tests' };
+	}
+}
+
+export const actions = {
+	upload: async ({ request, fetch }) => {
+		const formData = await request.formData();
+		const file = formData.get('sql_file');
+		if (!file) {
+			return fail(400, { error: 'No file provided' });
+		}
+		try {
+			await uploadSQL(fetch, file);
+			return { success: true };
+		} catch {
+			return fail(400, { error: 'Upload failed' });
+		}
+	}
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,33 +1,9 @@
 <script>
-	import { onMount } from 'svelte';
-	import { query, uploadSQL } from '$lib/api';
 	import logo from '$lib/assets/favicon.svg';
 
-	let tests = [];
-	let error = '';
-	let file;
-
-	async function loadTests() {
-		try {
-			const res = await query('select id, title, description from tests');
-			tests = Array.isArray(res) ? res : (res?.data ?? []);
-		} catch {
-			error = 'Failed to load tests';
-		}
-	}
-
-	onMount(loadTests);
-
-	async function handleUpload() {
-		if (!file) return;
-		try {
-			await uploadSQL(file);
-			file = null;
-			await loadTests();
-		} catch {
-			error = 'Upload failed';
-		}
-	}
+	let { data, form } = $props();
+	let tests = data.tests;
+	let error = data.error ?? '';
 </script>
 
 <main>
@@ -38,12 +14,14 @@
 
 	<section class="upload">
 		<h2>Upload Test (SQL)</h2>
-		<input type="file" accept=".sql" on:change={(e) => (file = e.target.files[0])} />
-		<button on:click|preventDefault={handleUpload}>Upload</button>
+		<form method="POST" enctype="multipart/form-data">
+			<input type="file" name="sql_file" accept=".sql" />
+			<button type="submit" formaction="?/upload">Upload</button>
+		</form>
 	</section>
 
-	{#if error}
-		<p class="error">{error}</p>
+	{#if form?.error || error}
+		<p class="error">{form?.error || error}</p>
 	{/if}
 
 	<section class="tests">

--- a/src/routes/api/query-file/+server.js
+++ b/src/routes/api/query-file/+server.js
@@ -1,0 +1,19 @@
+import { PUBLIC_PASSPHRASE } from '$env/static/public';
+
+const BASE_URL = 'https://web-production-b1513.up.railway.app';
+
+export async function POST({ request }) {
+	const formData = await request.formData();
+	const res = await fetch(`${BASE_URL}/query-file`, {
+		method: 'POST',
+		headers: {
+			...(PUBLIC_PASSPHRASE ? { Authorization: `Bearer ${PUBLIC_PASSPHRASE}` } : {})
+		},
+		body: formData
+	});
+	const text = await res.text();
+	return new Response(text, {
+		status: res.status,
+		headers: { 'Content-Type': 'application/json' }
+	});
+}

--- a/src/routes/api/query/+server.js
+++ b/src/routes/api/query/+server.js
@@ -1,0 +1,20 @@
+import { PUBLIC_PASSPHRASE } from '$env/static/public';
+
+const BASE_URL = 'https://web-production-b1513.up.railway.app';
+
+export async function POST({ request }) {
+	const body = await request.json();
+	const res = await fetch(`${BASE_URL}/query`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			...(PUBLIC_PASSPHRASE ? { Authorization: `Bearer ${PUBLIC_PASSPHRASE}` } : {})
+		},
+		body: JSON.stringify({ sql: body.sql, source: 'duckdb' })
+	});
+	const text = await res.text();
+	return new Response(text, {
+		status: res.status,
+		headers: { 'Content-Type': 'application/json' }
+	});
+}

--- a/src/routes/tests/[id]/+page.server.js
+++ b/src/routes/tests/[id]/+page.server.js
@@ -1,0 +1,46 @@
+import { query } from '$lib/api';
+
+function shuffle(arr) {
+	return arr.sort(() => Math.random() - 0.5);
+}
+
+export async function load({ params, fetch }) {
+	try {
+		const tRes = await query(fetch, `select id, title from tests where id = ${params.id}`);
+		const tData = Array.isArray(tRes) ? tRes : (tRes?.data ?? []);
+		const test = tData[0];
+
+		const qRes = await query(
+			fetch,
+			`select q.id as question_id, q.question_text, c.id as choice_id, c.choice_text, c.is_correct
+                        from questions q join choices c on q.id = c.question_id
+                        where q.test_id = ${params.id}`
+		);
+		const rows = Array.isArray(qRes) ? qRes : (qRes?.data ?? []);
+		const map = new Map();
+		for (const r of rows) {
+			if (!map.has(r.question_id)) {
+				map.set(r.question_id, {
+					id: r.question_id,
+					text: r.question_text,
+					choices: []
+				});
+			}
+			map.get(r.question_id).choices.push({
+				id: r.choice_id,
+				text: r.choice_text,
+				is_correct: r.is_correct
+			});
+		}
+		const questions = shuffle(
+			Array.from(map.values()).map((q) => ({
+				...q,
+				choices: shuffle(q.choices),
+				selected: null
+			}))
+		);
+		return { test, questions };
+	} catch {
+		return { error: 'Failed to load test' };
+	}
+}

--- a/src/routes/tests/[id]/+page.svelte
+++ b/src/routes/tests/[id]/+page.svelte
@@ -1,59 +1,11 @@
 <script>
-	import { query } from '$lib/api';
-	import { SvelteMap } from 'svelte';
-
-	let { params } = $props();
-	let test;
-	let questions = [];
+	let { data } = $props();
+	let test = data.test;
+	let questions = data.questions ?? [];
 	let student = '';
 	let submitted = false;
 	let score = 0;
-	let error = '';
-
-	function shuffle(arr) {
-		return arr.sort(() => Math.random() - 0.5);
-	}
-
-	async function load() {
-		try {
-			const tRes = await query(`select id, title from tests where id = ${params.id}`);
-			const tData = Array.isArray(tRes) ? tRes : (tRes?.data ?? []);
-			test = tData[0];
-
-			const qRes = await query(`
-                                select q.id as question_id, q.question_text, c.id as choice_id, c.choice_text, c.is_correct
-                                from questions q join choices c on q.id = c.question_id
-                                where q.test_id = ${params.id}
-                        `);
-			const rows = Array.isArray(qRes) ? qRes : (qRes?.data ?? []);
-			const map = new SvelteMap();
-			for (const r of rows) {
-				if (!map.has(r.question_id)) {
-					map.set(r.question_id, {
-						id: r.question_id,
-						text: r.question_text,
-						choices: []
-					});
-				}
-				map.get(r.question_id).choices.push({
-					id: r.choice_id,
-					text: r.choice_text,
-					is_correct: r.is_correct
-				});
-			}
-			questions = shuffle(
-				Array.from(map.values()).map((q) => ({
-					...q,
-					choices: shuffle(q.choices),
-					selected: null
-				}))
-			);
-		} catch {
-			error = 'Failed to load test';
-		}
-	}
-
-	load();
+	let error = data.error ?? '';
 
 	function submit() {
 		score = 0;


### PR DESCRIPTION
## Summary
- add SvelteKit API routes to forward query and SQL upload to the external service
- load test list and test details on the server with new `+page.server` files
- switch client pages to use form actions and server data instead of browser fetch calls

## Testing
- `npm test` *(fails: Playwright browsers missing)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891f6589fb88324979e1aecb91e3aef