### PR TITLE
Add PIN-based test management flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,44 @@ You can preview the production build with `npm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
 
+## User flows
+
+The app now uses simple PIN codes rather than full authentication. A teacher PIN is stored with each test and a student PIN is stored with each test attempt.
+
+### Upload a test from a spreadsheet
+
+1. Prepare a CSV file where each row is `question,correct answer,wrong answer 1,wrong answer 2...`.
+2. Call `uploadTestSpreadsheet` with the CSV file, a test title and your teacher PIN. The questions and choices will be created for you.
+
+### Manage tests
+
+- Toggle whether a test is active with `setTestActive`.
+- Update questions or answers by issuing SQL queries through the existing `query` helper.
+
+### Review test responses
+
+- Fetch aggregated results for your tests with `getTeacherResults(teacherPin)`.
+
+### Assign a test to a student
+
+- Use `assignTest` with a student's name and a unique student PIN. This creates a test attempt for the student.
+
+### Student review of results
+
+- Students can call `getStudentResults(studentPin)` to see scores and completion times for their attempts.
+
 ## Database migrations
 
 This project includes SQL migrations for the DuckDB backend. The scripts live in the `migrations/` directory. To apply the initial schema, upload the SQL file to the FastAPI service:
 
 ```sh
 curl -X POST -F "sql_file=@migrations/001_init.sql" https://web-production-b1513.up.railway.app/query-file
+```
+
+To add support for PIN codes and test activation, apply the additional migration:
+
+```sh
+curl -X POST -F "sql_file=@migrations/002_add_pins.sql" https://web-production-b1513.up.railway.app/query-file
 ```
 
 This will create the tables used by the app for tests, questions and student attempts.

--- a/migrations/002_add_pins.sql
+++ b/migrations/002_add_pins.sql
@@ -1,0 +1,7 @@
+---------------------------------------------------------------------
+-- Add PIN support for teachers and students and test activation flag
+---------------------------------------------------------------------
+ALTER TABLE tests ADD COLUMN teacher_pin TEXT NOT NULL DEFAULT '0000';
+ALTER TABLE tests ADD COLUMN is_active BOOLEAN NOT NULL DEFAULT TRUE;
+
+ALTER TABLE test_attempts ADD COLUMN student_pin TEXT NOT NULL DEFAULT '0000';

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -26,3 +26,38 @@ export async function uploadSQL(fetch, file) {
 	}
 	return res.json();
 }
+
+export async function uploadTestSpreadsheet(fetch, { file, title, teacherPin }) {
+	const form = new FormData();
+	form.append('file', file);
+	form.append('title', title);
+	form.append('teacher_pin', teacherPin);
+	const res = await fetch(`${BASE_URL}/tests/upload`, {
+		method: 'POST',
+		body: form
+	});
+	if (!res.ok) {
+		throw new Error(await res.text());
+	}
+	return res.json();
+}
+
+export async function assignTest(fetch, { testId, studentName, studentPin }) {
+	const sql = `INSERT INTO test_attempts (test_id, student_name, student_pin) VALUES (${testId}, '${studentName}', '${studentPin}')`;
+	return query(fetch, sql);
+}
+
+export async function setTestActive(fetch, { testId, teacherPin, isActive }) {
+	const sql = `UPDATE tests SET is_active = ${isActive ? 'TRUE' : 'FALSE'} WHERE id = ${testId} AND teacher_pin = '${teacherPin}'`;
+	return query(fetch, sql);
+}
+
+export async function getTeacherResults(fetch, teacherPin) {
+	const sql = `SELECT ta.student_name, ta.score, ta.completed_at, t.title FROM test_attempts ta JOIN tests t ON t.id = ta.test_id WHERE t.teacher_pin = '${teacherPin}'`;
+	return query(fetch, sql);
+}
+
+export async function getStudentResults(fetch, studentPin) {
+	const sql = `SELECT t.title, ta.score, ta.completed_at FROM test_attempts ta JOIN tests t ON t.id = ta.test_id WHERE ta.student_pin = '${studentPin}'`;
+	return query(fetch, sql);
+}

--- a/src/routes/api/tests/upload/+server.js
+++ b/src/routes/api/tests/upload/+server.js
@@ -1,0 +1,60 @@
+import { PUBLIC_PASSPHRASE } from '$env/static/public';
+
+const BASE_URL = 'https://web-production-b1513.up.railway.app';
+
+function escapeSql(str) {
+	return str.replace(/'/g, "''");
+}
+
+async function run(sql) {
+	const res = await fetch(`${BASE_URL}/query`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			...(PUBLIC_PASSPHRASE ? { Authorization: `Bearer ${PUBLIC_PASSPHRASE}` } : {})
+		},
+		body: JSON.stringify({ sql, source: 'duckdb' })
+	});
+	if (!res.ok) {
+		throw new Error(await res.text());
+	}
+	return res.json();
+}
+
+export async function POST({ request }) {
+	const formData = await request.formData();
+	const file = formData.get('file');
+	const title = formData.get('title');
+	const teacher_pin = formData.get('teacher_pin');
+	if (!file || !title || !teacher_pin) {
+		return new Response('Missing file, title or teacher_pin', { status: 400 });
+	}
+	const text = await file.text();
+	// create test
+	const testRow = await run(
+		`INSERT INTO tests (title, teacher_pin) VALUES ('${escapeSql(title)}', '${escapeSql(teacher_pin)}') RETURNING id`
+	);
+	const test_id = testRow[0].id;
+	const lines = text.trim().split(/\r?\n/);
+	for (const line of lines) {
+		if (!line) continue;
+		const cols = line.split(',');
+		if (cols.length < 2) continue; // need at least question and correct answer
+		const question_text = escapeSql(cols[0]);
+		const correct = escapeSql(cols[1]);
+		const wrongs = cols.slice(2).map((c) => escapeSql(c));
+		const qRow = await run(
+			`INSERT INTO questions (test_id, question_text) VALUES (${test_id}, '${question_text}') RETURNING id`
+		);
+		const question_id = qRow[0].id;
+		await run(
+			`INSERT INTO choices (question_id, choice_text, is_correct) VALUES (${question_id}, '${correct}', TRUE)`
+		);
+		for (const wrong of wrongs) {
+			await run(
+				`INSERT INTO choices (question_id, choice_text, is_correct) VALUES (${question_id}, '${wrong}', FALSE)`
+			);
+		}
+	}
+	return new Response(JSON.stringify({ test_id }), { status: 200 });
+}


### PR DESCRIPTION
## Summary
- document new teacher and student flows using PIN codes
- support uploading test questions from CSV
- add database migration for PIN columns and active flag
- expose API helpers for assigning tests and fetching results

## Testing
- `npm run lint`
- `npm test` *(fails: browserType.launch executable doesn't exist; run “npx playwright install”)*

------
https://chatgpt.com/codex/tasks/task_e_6891f98a15148324bf0d4427df0dac0b