### PR TITLE
Add admin user management and blank database setup

### DIFF
--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -51,26 +51,30 @@ CREATE TABLE IF NOT EXISTS attempt_answers (
 ---------------------------------------------------------------------
 -- 3. Seed data
 ---------------------------------------------------------------------
+--
+-- No default seed data. Database starts empty so it can be configured
+-- via the application's admin interface.
+--
 
 -- sample test
-INSERT INTO tests (title, description)
-VALUES ('Civics Sample', 'Basic questions about U.S. law');
+-- INSERT INTO tests (title, description)
+-- VALUES ('Civics Sample', 'Basic questions about U.S. law');
 
 -- sample questions
-INSERT INTO questions (test_id, question_text) VALUES
-    (1, 'What is the supreme law of the land?'),
-    (1, 'Who is in charge of the executive branch?');
+-- INSERT INTO questions (test_id, question_text) VALUES
+--    (1, 'What is the supreme law of the land?'),
+--    (1, 'Who is in charge of the executive branch?');
 
 -- choices for question 1
-INSERT INTO choices (question_id, choice_text, is_correct) VALUES
-    (1, 'The Constitution', TRUE),
-    (1, 'The Federalist Papers', FALSE),
-    (1, 'The Declaration of Independence', FALSE),
-    (1, 'The Articles of Confederation', FALSE);
+-- INSERT INTO choices (question_id, choice_text, is_correct) VALUES
+--    (1, 'The Constitution', TRUE),
+--    (1, 'The Federalist Papers', FALSE),
+--    (1, 'The Declaration of Independence', FALSE),
+--    (1, 'The Articles of Confederation', FALSE);
 
 -- choices for question 2
-INSERT INTO choices (question_id, choice_text, is_correct) VALUES
-    (2, 'The President', TRUE),
-    (2, 'The Chief Justice', FALSE),
-    (2, 'The Speaker of the House', FALSE),
-    (2, 'The Senate Majority Leader', FALSE);
+-- INSERT INTO choices (question_id, choice_text, is_correct) VALUES
+--    (2, 'The President', TRUE),
+--    (2, 'The Chief Justice', FALSE),
+--    (2, 'The Speaker of the House', FALSE),
+--    (2, 'The Senate Majority Leader', FALSE);

--- a/migrations/003_create_users.sql
+++ b/migrations/003_create_users.sql
@@ -1,0 +1,17 @@
+---------------------------------------------------------------------
+-- Create teachers and students tables
+---------------------------------------------------------------------
+CREATE SEQUENCE teachers_seq;
+CREATE SEQUENCE students_seq;
+
+CREATE TABLE IF NOT EXISTS teachers (
+    id   INTEGER PRIMARY KEY DEFAULT nextval('teachers_seq'),
+    name TEXT NOT NULL,
+    pin  TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS students (
+    id   INTEGER PRIMARY KEY DEFAULT nextval('students_seq'),
+    name TEXT NOT NULL,
+    pin  TEXT NOT NULL UNIQUE
+);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -85,6 +85,7 @@
                 <img src={logo} alt="Law Test Randomizer logo" />
                 <h1>Law Test Randomizer</h1>
         </header>
+        <nav class="admin-link"><a href="/admin">Admin</a></nav>
 
         {#if error}
                 <p class="error">{error}</p>
@@ -168,7 +169,7 @@
 		font-family: system-ui, sans-serif;
 	}
 
-	.brand {
+        .brand {
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -205,5 +206,14 @@
         .error {
                 color: #c00;
                 margin-top: 1rem;
+        }
+
+        .admin-link {
+                text-align: right;
+        }
+
+        .admin-link a {
+                color: #0d3b66;
+                text-decoration: none;
         }
 </style>

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -1,0 +1,67 @@
+<script>
+        import { addTeacher, addStudent } from '$lib/api';
+        let teacherName = '';
+        let teacherPin = '';
+        let teacherMsg = '';
+        async function handleAddTeacher() {
+                try {
+                        await addTeacher(fetch, { name: teacherName, pin: teacherPin });
+                        teacherMsg = 'Teacher added';
+                } catch {
+                        teacherMsg = 'Failed to add teacher';
+                }
+        }
+
+        let studentName = '';
+        let studentPin = '';
+        let studentMsg = '';
+        async function handleAddStudent() {
+                try {
+                        await addStudent(fetch, { name: studentName, pin: studentPin });
+                        studentMsg = 'Student added';
+                } catch {
+                        studentMsg = 'Failed to add student';
+                }
+        }
+</script>
+
+<main>
+        <h1>Admin</h1>
+        <section>
+                <h2>Add Teacher</h2>
+                <input type="text" placeholder="Name" bind:value={teacherName} />
+                <input type="text" placeholder="PIN" bind:value={teacherPin} />
+                <button on:click={handleAddTeacher}>Add Teacher</button>
+                {#if teacherMsg}<p>{teacherMsg}</p>{/if}
+        </section>
+        <section>
+                <h2>Add Student</h2>
+                <input type="text" placeholder="Name" bind:value={studentName} />
+                <input type="text" placeholder="PIN" bind:value={studentPin} />
+                <button on:click={handleAddStudent}>Add Student</button>
+                {#if studentMsg}<p>{studentMsg}</p>{/if}
+        </section>
+</main>
+
+<style>
+        main {
+                max-width: 60rem;
+                margin: 0 auto;
+                padding: 2rem;
+                font-family: system-ui, sans-serif;
+        }
+        section {
+                margin-top: 1.5rem;
+        }
+        button {
+                background-color: #0d3b66;
+                color: #fff;
+                border: none;
+                padding: 0.5rem 1rem;
+                border-radius: 0.25rem;
+                cursor: pointer;
+        }
+        button:hover {
+                background-color: #092745;
+        }
+</style>

--- a/src/routes/api/tests/upload/+server.js
+++ b/src/routes/api/tests/upload/+server.js
@@ -23,13 +23,19 @@ async function run(sql) {
 
 export async function POST({ request }) {
 	const formData = await request.formData();
-	const file = formData.get('file');
-	const title = formData.get('title');
-	const teacher_pin = formData.get('teacher_pin');
-	if (!file || !title || !teacher_pin) {
-		return new Response('Missing file, title or teacher_pin', { status: 400 });
-	}
-	const text = await file.text();
+        const file = formData.get('file');
+        const title = formData.get('title');
+        const teacher_pin = formData.get('teacher_pin');
+        if (!file || !title || !teacher_pin) {
+                return new Response('Missing file, title or teacher_pin', { status: 400 });
+        }
+        const teacherExists = await run(
+                `SELECT 1 FROM teachers WHERE pin = '${escapeSql(teacher_pin)}' LIMIT 1`
+        );
+        if (!Array.isArray(teacherExists) || teacherExists.length === 0) {
+                return new Response('Invalid teacher PIN', { status: 400 });
+        }
+        const text = await file.text();
 	// create test
 	const testRow = await run(
 		`INSERT INTO tests (title, teacher_pin) VALUES ('${escapeSql(title)}', '${escapeSql(teacher_pin)}') RETURNING id`


### PR DESCRIPTION
## Summary
- allow starting from a clean database by removing seed rows
- support separate teachers and students tables and API helpers
- add admin screen to register teachers and students
- validate teacher PIN during test uploads and student PIN on assignment

## Testing
- `npx playwright install chromium` *(failed: Download failed: server returned code 403)*
- `npm test` *(failed: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1181/chrome-linux/chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6892685c07a88324b7bba59ee33309eb