### PR TITLE
Read passphrase from .Env for server API requests

### DIFF
--- a/src/lib/server/env.js
+++ b/src/lib/server/env.js
@@ -1,0 +1,6 @@
+import { config } from 'dotenv';
+
+// Load variables from the .Env file if present
+config({ path: `${process.cwd()}/.Env` });
+
+export const PASSPHRASE = process.env.PASSPHRASE;

--- a/src/routes/api/query-file/+server.js
+++ b/src/routes/api/query-file/+server.js
@@ -1,4 +1,4 @@
-import { PASSPHRASE } from '$env/dynamic/private';
+import { PASSPHRASE } from '$lib/server/env';
 
 const BASE_URL = 'https://web-production-b1513.up.railway.app';
 

--- a/src/routes/api/query/+server.js
+++ b/src/routes/api/query/+server.js
@@ -1,4 +1,4 @@
-import { PASSPHRASE } from '$env/dynamic/private';
+import { PASSPHRASE } from '$lib/server/env';
 
 const BASE_URL = 'https://web-production-b1513.up.railway.app';
 

--- a/src/routes/api/tests/upload/+server.js
+++ b/src/routes/api/tests/upload/+server.js
@@ -1,4 +1,4 @@
-import { PASSPHRASE } from '$env/dynamic/private';
+import { PASSPHRASE } from '$lib/server/env';
 
 const BASE_URL = 'https://web-production-b1513.up.railway.app';
 


### PR DESCRIPTION
## Summary
- load `.Env` file on the server and expose `PASSPHRASE`
- send bearer token using `PASSPHRASE` for query-related API endpoints

## Testing
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68934555fdfc8324ba28c741842222cf