### PR TITLE
Use PUBLIC_PASSPHRASE env and pass bearer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ This will create the tables used by the app for tests, questions and student att
 
 ## Authentication
 
-API requests now require a bearer token. Set `PASSPHRASE` in your environment before running the app:
+API requests now require a bearer token. Set `PUBLIC_PASSPHRASE` in your environment before running the app:
 
 ```sh
-export PASSPHRASE=your_token_here
+export PUBLIC_PASSPHRASE=your_token_here
 npm run dev
 ```
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"lint": "prettier --check . && eslint .",
 		"test:unit": "vitest",
 		"test": "npm run test:unit -- --run && npm run test:e2e",
-		"test:e2e": "cross-env PASSPHRASE=\"dummy-passphrase\" playwright test"
+                "test:e2e": "cross-env PUBLIC_PASSPHRASE=\"dummy-passphrase\" playwright test"
 	},
 	"devDependencies": {
 		"@eslint/compat": "^1.2.5",

--- a/src/lib/server/env.js
+++ b/src/lib/server/env.js
@@ -1,6 +1,3 @@
-import { config } from 'dotenv';
+import { PUBLIC_PASSPHRASE } from '$env/static/public';
 
-// Load variables from the .Env file if present
-config({ path: `${process.cwd()}/.Env` });
-
-export const PASSPHRASE = process.env.PASSPHRASE;
+export { PUBLIC_PASSPHRASE };

--- a/src/routes/api/query-file/+server.js
+++ b/src/routes/api/query-file/+server.js
@@ -1,4 +1,4 @@
-import { PASSPHRASE } from '$lib/server/env';
+import { PUBLIC_PASSPHRASE } from '$lib/server/env';
 
 const BASE_URL = 'https://web-production-b1513.up.railway.app';
 
@@ -7,7 +7,7 @@ export async function POST({ request }) {
 	const res = await fetch(`${BASE_URL}/query-file`, {
 		method: 'POST',
 		headers: {
-			...(PASSPHRASE ? { Authorization: `Bearer ${PASSPHRASE}` } : {})
+                        ...(PUBLIC_PASSPHRASE ? { Authorization: `Bearer ${PUBLIC_PASSPHRASE}` } : {})
 		},
 		body: formData
 	});

--- a/src/routes/api/query/+server.js
+++ b/src/routes/api/query/+server.js
@@ -1,4 +1,4 @@
-import { PASSPHRASE } from '$lib/server/env';
+import { PUBLIC_PASSPHRASE } from '$lib/server/env';
 
 const BASE_URL = 'https://web-production-b1513.up.railway.app';
 
@@ -8,7 +8,7 @@ export async function POST({ request }) {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
-			...(PASSPHRASE ? { Authorization: `Bearer ${PASSPHRASE}` } : {})
+                        ...(PUBLIC_PASSPHRASE ? { Authorization: `Bearer ${PUBLIC_PASSPHRASE}` } : {})
 		},
 		body: JSON.stringify({ sql: body.sql, source: 'duckdb' })
 	});

--- a/src/routes/api/tests/upload/+server.js
+++ b/src/routes/api/tests/upload/+server.js
@@ -1,4 +1,4 @@
-import { PASSPHRASE } from '$lib/server/env';
+import { PUBLIC_PASSPHRASE } from '$lib/server/env';
 
 const BASE_URL = 'https://web-production-b1513.up.railway.app';
 
@@ -11,7 +11,7 @@ async function run(sql) {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
-			...(PASSPHRASE ? { Authorization: `Bearer ${PASSPHRASE}` } : {})
+                        ...(PUBLIC_PASSPHRASE ? { Authorization: `Bearer ${PUBLIC_PASSPHRASE}` } : {})
 		},
 		body: JSON.stringify({ sql, source: 'duckdb' })
 	});

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,38 +1,52 @@
 <script>
-	import { goto } from '$app/navigation';
-	import { user } from '$lib/user';
-	import { query } from '$lib/api';
+        import { goto } from '$app/navigation';
+        import { user } from '$lib/user';
+        import { query } from '$lib/api';
+        import { PUBLIC_PASSPHRASE } from '$env/static/public';
 
 	let pin = '';
 	let error = '';
 
-	async function login() {
-		error = '';
-		if (!/^\d+$/.test(pin)) {
-			error = 'PIN must be numeric';
-			return;
-		}
+async function login() {
+        error = '';
+        if (!/^\d+$/.test(pin)) {
+                error = 'PIN must be numeric';
+                return;
+        }
 
-		try {
-			const teacher = await query(fetch, `SELECT id, name, 'teacher' as role FROM teachers WHERE pin = '${pin}'`);
-			if (teacher.length > 0) {
-				$user = teacher[0];
-				goto('/');
-				return;
-			}
+        try {
+                const authedFetch = (input, init = {}) => {
+                        init.headers = {
+                                ...(init.headers || {}),
+                                Authorization: `Bearer ${PUBLIC_PASSPHRASE}`
+                        };
+                        return fetch(input, init);
+                };
+                const teacher = await query(
+                        authedFetch,
+                        `SELECT id, name, 'teacher' as role FROM teachers WHERE pin = '${pin}'`
+                );
+                if (teacher.length > 0) {
+                        $user = teacher[0];
+                        goto('/');
+                        return;
+                }
 
-			const student = await query(fetch, `SELECT id, name, 'student' as role FROM students WHERE pin = '${pin}'`);
-			if (student.length > 0) {
-				$user = student[0];
-				goto('/');
-				return;
-			}
+                const student = await query(
+                        authedFetch,
+                        `SELECT id, name, 'student' as role FROM students WHERE pin = '${pin}'`
+                );
+                if (student.length > 0) {
+                        $user = student[0];
+                        goto('/');
+                        return;
+                }
 
-			error = 'Invalid PIN';
-		} catch (e) {
-			error = e.message;
-		}
-	}
+                error = 'Invalid PIN';
+        } catch (e) {
+                error = e.message;
+        }
+}
 </script>
 
 <main class="container">


### PR DESCRIPTION
## Summary
- use SvelteKit env module for PUBLIC_PASSPHRASE in server routes
- send PUBLIC_PASSPHRASE as bearer token in login queries
- document PUBLIC_PASSPHRASE and update test script

## Testing
- `npm test` *(fails: Host system is missing dependencies to run browsers)*
- `npx playwright install` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68934aa86b908324927a965bb181eba6