### PR TITLE
Derive test details from file

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -54,21 +54,26 @@ export async function uploadSQL(fetch, file) {
 }
 
 export async function uploadTestSpreadsheet(fetch, { file, title, teacherId }) {
-	validateString(title);
-	validateNumeric(teacherId);
+        if (!file) {
+                throw new Error('File is required');
+        }
 
-	const form = new FormData();
-	form.append('file', file);
-	form.append('title', title);
-	form.append('teacher_id', teacherId);
-	const res = await fetch(`${BASE_URL}/tests/upload`, {
-		method: 'POST',
-		body: form
-	});
-	if (!res.ok) {
-		throw new Error(await res.text());
-	}
-	return res.json();
+        const derivedTitle = title?.trim() || file.name.replace(/\.[^/.]+$/, '');
+        const cleanTitle = validateString(derivedTitle);
+        const cleanTeacherId = validateNumeric(teacherId);
+
+        const form = new FormData();
+        form.append('file', file);
+        form.append('title', cleanTitle);
+        form.append('teacher_id', cleanTeacherId);
+        const res = await fetch(`${BASE_URL}/tests/upload`, {
+                method: 'POST',
+                body: form
+        });
+        if (!res.ok) {
+                throw new Error(await res.text());
+        }
+        return res.json();
 }
 
 export async function assignTest(fetch, { testId, studentId, studentName }) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -17,18 +17,19 @@
 	let title = '';
 	let uploadMsg = '';
 
-	async function handleUpload() {
-		if (!$user || $user.role !== 'teacher') {
-			uploadMsg = 'You must be logged in as a teacher to upload tests.';
-			return;
-		}
-		try {
-			await uploadTestSpreadsheet(fetch, { file, title, teacherId: $user.id });
-			uploadMsg = 'Uploaded';
-		} catch {
-			uploadMsg = 'Upload failed';
-		}
-	}
+        async function handleUpload() {
+                if (!$user || $user.role !== 'teacher') {
+                        uploadMsg = 'You must be logged in as a teacher to upload tests.';
+                        return;
+                }
+                const autoTitle = title.trim() || file?.name?.replace(/\.[^/.]+$/, '');
+                try {
+                        await uploadTestSpreadsheet(fetch, { file, title: autoTitle, teacherId: $user.id });
+                        uploadMsg = 'Uploaded';
+                } catch {
+                        uploadMsg = 'Upload failed';
+                }
+        }
 
 	async function toggleActive(t) {
 		if (!$user || $user.role !== 'teacher') {
@@ -114,12 +115,21 @@
 		{#if $user.role === 'teacher'}
 			<section class="upload">
 				<h2>Upload Test (Spreadsheet)</h2>
-				<input type="text" placeholder="Title" bind:value={title} />
-				<input type="file" accept=".csv" on:change={(e) => (file = e.target.files[0])} />
-				<button on:click={handleUpload}>Upload</button>
-				{#if uploadMsg}
-					<p>{uploadMsg}</p>
-				{/if}
+                                <input type="text" placeholder="Title" bind:value={title} />
+                                <input
+                                        type="file"
+                                        accept=".csv"
+                                        on:change={(e) => {
+                                                file = e.target.files[0];
+                                                if (!title) {
+                                                        title = file?.name?.replace(/\.[^/.]+$/, '');
+                                                }
+                                        }}
+                                />
+                                <button on:click={handleUpload}>Upload</button>
+                                {#if uploadMsg}
+                                        <p>{uploadMsg}</p>
+                                {/if}
 			</section>
 
 			<section class="tests">

--- a/src/routes/api/tests/upload/+server.js
+++ b/src/routes/api/tests/upload/+server.js
@@ -22,16 +22,21 @@ async function run(sql) {
 }
 
 export async function POST({ request }) {
-	const formData = await request.formData();
-	const file = formData.get('file');
-	const title = formData.get('title');
-	const teacher_id = formData.get('teacher_id');
-	if (!file || !title || !teacher_id) {
-		return new Response('Missing file, title or teacher_id', { status: 400 });
-	}
-	if (!/^\d+$/.test(teacher_id)) {
-		return new Response('Invalid teacher_id format', { status: 400 });
-	}
+        const formData = await request.formData();
+        const file = formData.get('file');
+        let title = formData.get('title');
+        let teacher_id = formData.get('teacher_id') || request.headers.get('x-teacher-id');
+
+        if (file && !title) {
+                title = file.name.replace(/\.[^/.]+$/, '');
+        }
+
+        if (!file || !title || !teacher_id) {
+                return new Response('Missing file, title or teacher_id', { status: 400 });
+        }
+        if (!/^\d+$/.test(teacher_id)) {
+                return new Response('Invalid teacher_id format', { status: 400 });
+        }
 	const text = await file.text();
 	// create test
 	const testRow = await run(


### PR DESCRIPTION
## Summary
- Auto-fill test title from uploaded CSV file name and teacher session
- Populate upload form's title field based on file selection
- Allow API to infer missing title and teacher id from request metadata

## Testing
- `npm test` *(fails: Host system is missing dependencies to run browsers)*


------
https://chatgpt.com/codex/tasks/task_e_6893bd8101c083248546da23bd9acba7