### PR TITLE
Add class enrollment requests and approval workflow

### DIFF
--- a/migrations/003_add_class_status.sql
+++ b/migrations/003_add_class_status.sql
@@ -1,0 +1,2 @@
+-- Add status column to classes table for pending and active states
+ALTER TABLE classes ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'active';

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -139,7 +139,27 @@ export async function addStudent(fetch, { name, pin, teacherId }) {
 
 export async function getClassStudents(fetch, teacherId) {
 	const cleanTeacherId = validateNumeric(teacherId);
-	const sql = `SELECT s.id, s.name FROM classes c JOIN students s ON s.id = c.student_id WHERE c.teacher_id = ${cleanTeacherId}`;
+	const sql = `SELECT s.id, s.name FROM classes c JOIN students s ON s.id = c.student_id WHERE c.teacher_id = ${cleanTeacherId} AND c.status = 'active'`;
+	return query(fetch, sql);
+}
+
+export async function requestClassJoin(fetch, { studentId, teacherPin }) {
+	const cleanStudentId = validateNumeric(studentId);
+	const cleanTeacherPin = validateNumeric(teacherPin);
+	const sql = `INSERT INTO classes (teacher_id, student_id, status) SELECT id, ${cleanStudentId}, 'pending' FROM teachers WHERE pin = '${escapeSql(cleanTeacherPin)}' ON CONFLICT (teacher_id, student_id) DO UPDATE SET status = 'pending'`;
+	return query(fetch, sql);
+}
+
+export async function getPendingStudents(fetch, teacherId) {
+	const cleanTeacherId = validateNumeric(teacherId);
+	const sql = `SELECT s.id, s.name FROM classes c JOIN students s ON s.id = c.student_id WHERE c.teacher_id = ${cleanTeacherId} AND c.status = 'pending'`;
+	return query(fetch, sql);
+}
+
+export async function approveStudent(fetch, { teacherId, studentId }) {
+	const cleanTeacherId = validateNumeric(teacherId);
+	const cleanStudentId = validateNumeric(studentId);
+	const sql = `UPDATE classes SET status = 'active' WHERE teacher_id = ${cleanTeacherId} AND student_id = ${cleanStudentId}`;
 	return query(fetch, sql);
 }
 


### PR DESCRIPTION
## Summary
- allow students to request to join a teacher's class and teachers to approve requests
- track class membership with `status` column

## Testing
- `npm run lint` *(fails: Code style issues found in 11 files)*
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_6893f740be208324bafd6480812c638b