### PR TITLE
Fix teacher portal pending request display

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -53,10 +53,10 @@
 	}
 
 	let assignTestId = '';
-	let students = [];
+	let students = $state([]);
 	let selectedStudentId = '';
 	let assignMsg = '';
-	let pendingStudents = [];
+	let pendingStudents = $state([]);
 
 	async function loadStudents() {
 		if (!$user || $user.role !== 'teacher') {

--- a/src/routes/page.svelte.spec.js
+++ b/src/routes/page.svelte.spec.js
@@ -1,7 +1,25 @@
 import { page } from '@vitest/browser/context';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, afterEach } from 'vitest';
 import { render } from 'vitest-browser-svelte';
+import { user } from '$lib/user';
+
+vi.mock('$lib/api', () => ({
+	uploadTestSpreadsheet: vi.fn(),
+	setTestActive: vi.fn(),
+	assignTest: vi.fn(),
+	getTeacherResults: vi.fn(),
+	getStudentResults: vi.fn(),
+	getClassStudents: vi.fn().mockResolvedValue([]),
+	requestClassJoin: vi.fn(),
+	getPendingStudents: vi.fn().mockResolvedValue([{ id: 1, name: 'Alice' }]),
+	approveStudent: vi.fn()
+}));
+
 import Page from './+page.svelte';
+
+afterEach(() => {
+	user.set(null);
+});
 
 describe('/+page.svelte', () => {
 	it('should render h1', async () => {
@@ -15,5 +33,19 @@ describe('/+page.svelte', () => {
 
 		const heading = page.getByRole('heading', { level: 1 });
 		await expect.element(heading).toBeInTheDocument();
+	});
+
+	it('shows pending student requests', async () => {
+		user.set({ id: 1, role: 'teacher' });
+		render(Page, {
+			props: {
+				data: {
+					tests: []
+				}
+			}
+		});
+
+		const item = page.getByText('Alice');
+		await expect.element(item).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## Summary
- ensure student and pending request lists use Svelte state so teacher dashboard updates when fetched
- add browser test that mocks API and confirms pending student requests are rendered for teachers

## Testing
- `npx playwright install` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_6893fdb9c3188324bc593d07907aa28d