### PR TITLE
Show assigned tests on student dashboard

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -106,7 +106,7 @@ export async function getTeacherResults(fetch, teacherId) {
 
 export async function getStudentResults(fetch, studentId) {
 	const cleanStudentId = validateNumeric(studentId);
-	const sql = `SELECT t.title, ta.score, ta.completed_at FROM test_attempts ta JOIN tests t ON t.id = ta.test_id WHERE ta.student_id = ${cleanStudentId}`;
+	const sql = `SELECT t.id AS test_id, t.title, ta.score, ta.completed_at FROM test_attempts ta JOIN tests t ON t.id = ta.test_id WHERE ta.student_id = ${cleanStudentId}`;
 	return query(fetch, sql);
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -273,12 +273,18 @@
 			</section>
 
 			<section class="student-results">
-				<h2>My Results</h2>
+				<h2>My Tests</h2>
 				<button on:click={loadStudentResults}>Load</button>
 				{#if studentResults.length}
 					<ul>
 						{#each studentResults as r}
-							<li>{r.title}: {r.score}</li>
+							<li>
+								{#if r.score == null}
+									<a href={`/tests/${r.test_id}`}>{r.title}</a>
+								{:else}
+									{r.title}: {r.score}
+								{/if}
+							</li>
 						{/each}
 					</ul>
 				{/if}

--- a/src/routes/page.svelte.spec.js
+++ b/src/routes/page.svelte.spec.js
@@ -2,6 +2,7 @@ import { page } from '@vitest/browser/context';
 import { describe, expect, it, vi, afterEach } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { user } from '$lib/user';
+import { getStudentResults } from '$lib/api';
 
 vi.mock('$lib/api', () => ({
 	uploadTestSpreadsheet: vi.fn(),
@@ -47,5 +48,25 @@ describe('/+page.svelte', () => {
 
 		const item = page.getByText('Alice');
 		await expect.element(item).toBeInTheDocument();
+	});
+
+	it('displays assigned tests for students', async () => {
+		user.set({ id: 2, role: 'student' });
+		getStudentResults.mockResolvedValue([
+			{ test_id: 1, title: 'Test', score: null, completed_at: null }
+		]);
+		render(Page, {
+			props: {
+				data: {
+					tests: []
+				}
+			}
+		});
+
+		const loadBtn = page.getByRole('button', { name: 'Load' });
+		await loadBtn.click();
+
+		const link = page.getByRole('link', { name: 'Test' });
+		await expect.element(link).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## Summary
- include `test_id` in student results API query
- display assigned tests with links for students
- test coverage for student assignments

## Testing
- `npm run lint`
- `npm test` *(fails: browserType.launch: Executable doesn't exist)*
- `npx playwright install` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68940025d0648324a6a7e50f21b952b7