### PR TITLE
feat: support long response questions

### DIFF
--- a/migrations/005_long_response.sql
+++ b/migrations/005_long_response.sql
@@ -1,0 +1,5 @@
+ALTER TABLE questions ADD COLUMN points INTEGER DEFAULT 1;
+ALTER TABLE attempt_answers ALTER COLUMN choice_id DROP NOT NULL;
+ALTER TABLE attempt_answers ALTER COLUMN is_correct DROP NOT NULL;
+ALTER TABLE attempt_answers ADD COLUMN answer_text TEXT;
+ALTER TABLE attempt_answers ADD COLUMN points_awarded INTEGER;

--- a/src/routes/tests/[id]/+page.server.js
+++ b/src/routes/tests/[id]/+page.server.js
@@ -11,8 +11,8 @@ export async function load({ params, fetch }) {
 
 		const qRes = await query(
 			fetch,
-			`select q.id as question_id, q.question_text, c.id as choice_id, c.choice_text, c.is_correct
-                        from questions q join choices c on q.id = c.question_id
+			`select q.id as question_id, q.question_text, q.points, c.id as choice_id, c.choice_text, c.is_correct
+                        from questions q left join choices c on q.id = c.question_id
                         where q.test_id = ${params.id}`
 		);
 		const rows = Array.isArray(qRes) ? qRes : (qRes?.data ?? []);
@@ -22,14 +22,17 @@ export async function load({ params, fetch }) {
 				map.set(r.question_id, {
 					id: r.question_id,
 					text: r.question_text,
+					points: r.points,
 					choices: []
 				});
 			}
-			map.get(r.question_id).choices.push({
-				id: r.choice_id,
-				text: r.choice_text,
-				is_correct: r.is_correct
-			});
+			if (r.choice_id) {
+				map.get(r.question_id).choices.push({
+					id: r.choice_id,
+					text: r.choice_text,
+					is_correct: r.is_correct
+				});
+			}
 		}
 		const questions = Array.from(map.values()).map((q) => ({
 			...q,


### PR DESCRIPTION
## Summary
- add migration and API changes for long response questions with manual grading
- render free-response inputs and point values, defer scoring until graded
- allow teachers to override answers and grade submissions

## Testing
- `npm test` *(fails: Executable doesn't exist... Playwright install 403)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae0bca75248324bbbc864424d2929e