### PR TITLE
Fix preview update when pasting test data

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -423,15 +423,18 @@
 		}
 	});
 
-	// Reactive preview update when test data changes
-	$effect(() => {
-		const parsed = parseTestData(testData);
-		if (updateMode && existingQuestions.length > 0) {
-			previewQuestions = compareQuestions(parsed, existingQuestions);
-		} else {
-			previewQuestions = parsed.map((q) => ({ ...q, status: 'added' }));
-		}
-	});
+       function updatePreview() {
+               const parsed = parseTestData(testData);
+               if (updateMode && existingQuestions.length > 0) {
+                       previewQuestions = compareQuestions(parsed, existingQuestions);
+               } else {
+                       previewQuestions = parsed.map((q) => ({ ...q, status: 'added' }));
+               }
+               previewQuestions._sections = parsed._sections;
+       }
+
+       // Reactive preview update when test data changes
+       $effect(updatePreview);
 
 	// Load existing questions when update mode or selected test changes
 	$effect(() => {
@@ -642,10 +645,11 @@
 											<textarea
 												id="test-data"
 												placeholder="Paste your test data here. Use CSV format with commas to separate columns. Download template for examples."
-												bind:value={testData}
-												class="form-textarea"
-												rows="12"
-											></textarea>
+                                                                                                bind:value={testData}
+                                                                                                on:input={updatePreview}
+                                                                                                class="form-textarea"
+                                                                                                rows="12"
+                                                                                        ></textarea>
 										</div>
 										<div class="preview-section">
 											<div class="preview-header">


### PR DESCRIPTION
## Summary
- Update preview parsing to run via dedicated `updatePreview` function
- Trigger preview refresh on textarea input events

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181)*

------
https://chatgpt.com/codex/tasks/task_e_68b0707e18a483249873f08d1fec317c