### PR TITLE
Fix reviewer assignment loading

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1209,17 +1209,17 @@ export async function getReviewerAssignments(fetch, reviewerId) {
 		throw new Error('Invalid reviewer ID');
 	}
 	
-	const sql = `SELECT DISTINCT ra.id, ra.title, ra.description, t.title as test_title,
-	                    teacher.name as assigner_name, ra.created_at,
-	                    COUNT(qr.id) as total_questions,
-	                    COUNT(CASE WHEN qr.status = 'completed' THEN 1 END) as completed_questions
-	             FROM review_assignments ra
-	             JOIN tests t ON ra.test_id = t.id
-	             JOIN teachers teacher ON ra.assigner_id = teacher.id
-	             JOIN question_reviews qr ON ra.id = qr.assignment_id
-	             WHERE qr.reviewer_id = ${cleanReviewerId} AND ra.status = 'active'
-	             GROUP BY ra.id, ra.title, ra.description, t.title, teacher.name, ra.created_at
-	             ORDER BY ra.created_at DESC`;
+        const sql = `SELECT DISTINCT ra.id, ra.title, ra.description, t.title as test_title,
+                            teacher.name as assigner_name, ra.created_at,
+                            COUNT(qr.id) as total_questions,
+                            COUNT(CASE WHEN qr.status = 'completed' THEN 1 END) as completed_questions
+                     FROM review_assignments ra
+                     JOIN tests t ON ra.test_id = t.id
+                     JOIN teachers teacher ON ra.assigner_id = teacher.id
+                     LEFT JOIN question_reviews qr ON ra.id = qr.assignment_id AND qr.reviewer_id = ${cleanReviewerId}
+                     WHERE ra.status = 'active'
+                     GROUP BY ra.id, ra.title, ra.description, t.title, teacher.name, ra.created_at
+                     ORDER BY ra.created_at DESC`;
 	return query(fetch, sql);
 }
 


### PR DESCRIPTION
## Summary
- Adjust reviewer assignment query to include assignments even if no questions yet by using LEFT JOIN on question_reviews

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ec7cf5788324aad73fd465def68f