### PR TITLE
Switch backend source to Cloudflare D1

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The app now uses session-backed passphrases for authentication. Teachers, studen
 
 ## Database migrations
 
-This project includes SQL migrations for the DuckDB backend. The scripts live in the `migrations/` directory. To apply the initial schema, upload the SQL file to the FastAPI service:
+This project includes SQL migrations for the Cloudflare D1 backend. The scripts live in the `migrations/` directory. To apply the initial schema, upload the SQL file to the FastAPI service:
 
 ```sh
 curl -X POST -F "sql_file=@migrations/001_init.sql" https://web-production-b1513.up.railway.app/query-file

--- a/migrations/007_ensure_points_column.sql
+++ b/migrations/007_ensure_points_column.sql
@@ -8,4 +8,4 @@ ALTER TABLE attempt_answers ADD COLUMN IF NOT EXISTS answer_text TEXT;
 ALTER TABLE attempt_answers ADD COLUMN IF NOT EXISTS points_awarded INTEGER;
 
 -- Make choice_id nullable if it isn't already (for long response questions)
--- Note: DuckDB may not support conditional column modifications, so this might need to be handled differently
+-- Note: Cloudflare D1 (SQLite) may not support conditional column modifications, so this might need to be handled differently

--- a/migrations/011_fix_review_system.sql
+++ b/migrations/011_fix_review_system.sql
@@ -2,9 +2,9 @@
 -- Fixes the inconsistencies in the review assignment system
 
 -- Check if question_reviews_new exists and handle it
--- DuckDB doesn't support procedural blocks, so we'll handle this with conditional statements
+-- Cloudflare D1 (SQLite) doesn't support procedural blocks, so we'll handle this with conditional statements
 
--- DuckDB doesn't have complex conditional logic, so we'll use a simpler approach
+-- Cloudflare D1 (SQLite) doesn't have complex conditional logic, so we'll use a simpler approach
 -- Drop and recreate the question_reviews table with the correct structure
 
 -- Drop the question_reviews table if it exists (it may have wrong structure)
@@ -44,7 +44,7 @@ ALTER TABLE question_reviews ADD CONSTRAINT fk_question_reviews_reviewer_id
 ALTER TABLE question_reviews ADD CONSTRAINT fk_question_reviews_assignment_id 
     FOREIGN KEY (assignment_id) REFERENCES review_assignments(id);
 
--- Create indexes for better performance (DuckDB compatible)
+-- Create indexes for better performance (Cloudflare D1 compatible)
 CREATE INDEX idx_question_reviews_assignment_id ON question_reviews(assignment_id);
 CREATE INDEX idx_question_reviews_reviewer_id ON question_reviews(reviewer_id);
 CREATE INDEX idx_question_reviews_question_id ON question_reviews(question_id);

--- a/migrations/011_fix_review_system_v2.sql
+++ b/migrations/011_fix_review_system_v2.sql
@@ -1,4 +1,4 @@
--- Migration 011: Fix Review System (DuckDB Compatible Version)
+-- Migration 011: Fix Review System (Cloudflare D1 Compatible Version)
 -- Fixes the inconsistencies in the review assignment system
 
 -- Drop existing tables to start fresh

--- a/src/lib/server/db.js
+++ b/src/lib/server/db.js
@@ -117,7 +117,7 @@ function bindParameters(text, values = []) {
 
 function resolveQueryPayload(sqlOrConfig, options = {}) {
         const { source: optionSource, values: optionValues } = options;
-        let source = optionSource ?? 'duckdb';
+        let source = optionSource ?? 'd1';
 
         if (typeof sqlOrConfig === 'string') {
                 const values = optionValues ?? [];


### PR DESCRIPTION
## Summary
- default the backend query source to Cloudflare D1
- update documentation and migration comments to reference Cloudflare D1 instead of DuckDB

## Testing
- npm run lint *(fails: existing Prettier formatting warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_690aa0db68888323961fad4496801569